### PR TITLE
Fix SeeMore and SeeLess bug

### DIFF
--- a/src/components/Home/Ecosystem/Ecosystem.js
+++ b/src/components/Home/Ecosystem/Ecosystem.js
@@ -180,8 +180,8 @@ export default function Ecosystem(props) {
         </Grid>
         <More href="#" onClick={() => setMoreApps(!moreApps)}>
           {moreApps
-            ? `${t("home.ecosystem.seeMore")}} - `
-            : `${t("home.ecosystem.seeLess")} +`}
+            ? `${t("home.ecosystem.seeLess")} -`
+            : `${t("home.ecosystem.seeMore")} +`}
         </More>
       </Section>
       <Section>


### PR DESCRIPTION
Noticed that "See more" and "See less" are actually mixed up, see pictures below.

In theory, this fix should not interfere with anything else, but please double-check - I didn't verify this 100%.

![Example 1](https://user-images.githubusercontent.com/5999310/90549087-43f5a880-e18e-11ea-8845-d9f68251590f.png)

![Example 2](https://user-images.githubusercontent.com/5999310/90549096-46f09900-e18e-11ea-927e-871bb47567ab.png)
