### PR TITLE
Changing spanish from "Lanzar App" to "Abrir App"

### DIFF
--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -33,7 +33,7 @@
       "tor": "Usa ENS para acceder más fácilmente a los servicios ocultos de Tor .onion."
     },
     "carousel": {
-      "launch": "Lanzar App",
+      "launch": "Abrir App",
       "manage": "organiza",
       "register": "registra",
       "search": "busca"
@@ -91,6 +91,6 @@
   "nav": {
     "about": "Organización",
     "blog": "Blog",
-    "launch": "Lanzar App"
+    "launch": "Abrir App"
   }
 }


### PR DESCRIPTION
"Lanzar App" does not make sense in Spanish.