### PR TITLE
[196] Make language switcher mobile friendly

### DIFF
--- a/src/components/LanguageSwitcher.js
+++ b/src/components/LanguageSwitcher.js
@@ -197,13 +197,14 @@ export default function LanguageSwitcher({ mobile }) {
         <AnimatePresence>
           <Dropdown
             mobile={mobile}
-            initial={{ opacity: 0, height: 0 }}
-            animate={{ opacity: 1, height: "auto" }}
+            initial={{ opacity: 0, height: 0, overflowY: 'hidden', maxHeight: '60vh' }}
+            animate={{ opacity: 1, height: "auto", overflowY: 'auto'  }}
+            
             exit={{ opacity: 0, height: 0 }}
           >
             {LANGUAGES.map(language => {
               return (
-                <Link to={originalPath} language={language.value}>
+                <Link to={originalPath} language={language.value} key={language.value}>
                   <span>{language.label}</span>
                   <Ball selected={selectedLanguage.value === language.value} />
                 </Link>

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -20,7 +20,7 @@ const Nav = styled("nav")`
   justify-content: space-between;
   padding: 20px 40px;
   position: sticky;
-  z-index: 100000;
+  z-index: 2147483647;
   top: 0;
 
   .mobile-nav {


### PR DESCRIPTION
Fixes https://github.com/ensdomains/ensdomains-v2/issues/196 and https://github.com/ensdomains/ensdomains-v2/issues/314



Fix applies to both mobile and desktop when the screen can't fit the full list by making it scrollable if the list takes over 60vh

![image](https://user-images.githubusercontent.com/33531423/141663359-4244934c-75b7-4d50-9d94-729f516a9813.png)


![image](https://user-images.githubusercontent.com/33531423/141663373-7f2cd20e-5763-4f42-8993-261f8c8f5149.png)

![image](https://user-images.githubusercontent.com/33531423/141663376-5bb6cd88-1e2f-4a0f-b446-a19fbba8b4cf.png)


Works the same as it does currently if the list can fit (no scrolling needed)