### PR TITLE
chore: update license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 gatsbyjs
+Copyright (c) 2022 Ethereum Name Service
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
We are using the Gatsby framework and it means not necessarily want to use their name in the license

https://github.com/ensdomains/ens-app/blob/dev/LICENSE#L3