### PR TITLE
Fix ID for #get-support section

### DIFF
--- a/src/components/GetInvolved.js
+++ b/src/components/GetInvolved.js
@@ -155,7 +155,7 @@ export default function GetInvolved(props) {
           ))}
         </Links>
       </Container>
-      <Container id="get-involved" style={{ paddingTop: 0 }}>
+      <Container id="get-support" style={{ paddingTop: 0 }}>
         <AnchorContainer href={"#get-support"}>
           <H2>
             {t("home.getInvolved.supportTitle")}


### PR DESCRIPTION
Support section had the incorrect ID preventing the permalink from working.