### PR TITLE
Fix horizontal scroll issue

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -100,6 +100,7 @@ export default function Layout({ children, data, location }) {
         styles={css`
           html, body, #___gatsby, #gatsby-focus-wrapper {
             height: ${location?.pathname === '/governance' ? '100%' : 'initial'};
+            overflow-x: hidden;
           }
           body {
             font-family: Overpass;


### PR DESCRIPTION
## Description
* I noticed a horizontal scroll on the webpage (caused by the "search/register/manage" selector). 
* Using the selector creates an empty body on the right, causing horizontal scroll (see screenshot, changed bg to red). 
* Not a big deal ofc, but the fix improves ux. 

## Screenshots
![image](https://user-images.githubusercontent.com/75273616/219965305-20505226-69be-4289-aaf4-99aa562f5afa.png)
![image](https://user-images.githubusercontent.com/75273616/219965310-9ed7b1af-614d-4fd2-a7ca-2003e06f66d4.png)

